### PR TITLE
Improve formatting of table in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,24 @@ This project is a CLI to shorten the docker commands and compose multiple docker
 
 Shorts:
 
-| impl | cli            | original              | description                              |
-| ---- | -------------- | --------------------- | ---------------------------------------- |
-| [x]  | dc i           | docker images         |                                          |
-| []   | dc c *(dc ps)* | docker ps             |                                          |
-| []   | dc n           | docker network ls     |                                          |
-| []   | dc v           | docker volume ls      |                                          |
-| []   | dc i p         | docker image prune -f |                                          |
-| []   | dc io          | docker image          | forwards the options to original command |
-| []   | dc co          | docker container      | forwards the options to original command |
-| []   | dc no          | docker network        | forwards the options to original command |
-| []   | dc vo          | docker volume         | forwards the options to original command |
+| impl    | cli              | original                | description                              |
+| ------- | -----------------| ----------------------- | ---------------------------------------- |
+| &check; | `dc i`           | `docker images`         |                                          |
+| &#9744; | `dc c *(dc ps)*` | `docker ps`             |                                          |
+| &#9744; | `dc n`           | `docker network ls`     |                                          |
+| &#9744; | `dc v`           | `docker volume ls`      |                                          |
+| &#9744; | `dc i p`         | `docker image prune -f` |                                          |
+| &#9744; | `dc io`          | `docker image`          | forwards the options to original command |
+| &#9744; | `dc co`          | `docker container`      | forwards the options to original command |
+| &#9744; | `dc no`          | `docker network`        | forwards the options to original command |
+| &#9744; | `dc vo`          | `docker volume`         | forwards the options to original command |
 
 Compose:
 
-| impl | cli                  | orig                              | description                                                       |
-| ---- | -------------------- | --------------------------------- | ----------------------------------------------------------------- |
-| []   | dc b [name] \<file\> | docker build -t \<name\> \<file\> | builds image and remembers Dockerfile location                    |
-| []   | dc i r \<ID\>        |                                   | rebuild the image and remove container and dangling of that image |
+| impl    | cli                    | orig                                | description                                                       |
+| ------- | ---------------------- | ----------------------------------- | ----------------------------------------------------------------- |
+| &#9744; | `dc b [name] \<file\>` | `docker build -t \<name\> \<file\>` | builds image and remembers Dockerfile location                    |
+| &#9744; | `dc i r \<ID\>`        |                                     | rebuild the image and remove container and dangling of that image |
 
 ## More Details
 


### PR DESCRIPTION
Table is easier to read if the commands are highlighted as code:

![image](https://user-images.githubusercontent.com/12248527/63122678-9a427100-bfa7-11e9-9a71-24814077cbca.png)
