### PR TITLE
Reduce module size by ignoring files in prod mode

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+.devcontainer
+.vscode
+src
+.eslintrc.js
+.prettierrc
+.travis.yml
+nodemon.json
+tsconfig.json
+*.js.map


### PR DESCRIPTION
You can reduce the overall size of your npm module by approximately 50%:

If you run `npm pack` without the `.npmignore` file:
```
npm notice package size:  8.8 kB
npm notice unpacked size: 28.9 kB
```
and with `.npmignore` file:
```
npm notice package size:  4.5 kB
npm notice unpacked size: 12.8 kB
```

https://docs.npmjs.com/using-npm/developers.html#keeping-files-out-of-your-package