### PR TITLE
Open config with default editor for JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ export interface Config {
 		// The value is a docker command with placeholders
 		[commandMapping: string]: string;
 	};
-	// open in editor command, needs to contain one placeholder $0 for the config file path
-	openEditorCommand: string
 }
 ```
 
@@ -123,8 +121,7 @@ When you install the extension for the first time, this config will be created. 
 		bash: 'docker exec -it $0 /bin/bash',
 		rmdang: "docker rmi $(docker images -f 'dangling=true' -q)",
 		rmall: 'docker rm -v $(docker ps -aq)'
-	},
-	openEditorCommand: 'code $0'
+	}
 }
 ```
 ## Hirarchy of execution
@@ -148,7 +145,7 @@ The extension supports two extension specific functions.
 - `dc extension help` print help text
 - `dc extension get-config` prints the config location.
 - `dc extension save-config <file-path>` override the config with the given file.
-- `dc extension edit` open config in configured editor (`config.openEditorCommand`)
+- `dc extension edit` open config in system's default editor
 - `dc extension version` print version number
 
 ## Custom Commands

--- a/package-lock.json
+++ b/package-lock.json
@@ -3288,6 +3288,11 @@
         }
       }
     },
+    "is-docker": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
+      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
+    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -4005,6 +4010,25 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "open": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.0.4.tgz",
+      "integrity": "sha512-brSA+/yq+b08Hsr4c8fsEW2CRzk1BmfN3SAK/5VCHQ9bdoZJ4qa/+AfR0xHjlbbZUyPkUHs1b8x1RqdyZdkVqQ==",
+      "requires": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "requires": {
+            "is-docker": "^2.0.0"
+          }
+        }
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "url": "https://github.com/NicoVogel/docker_extension/issues"
   },
   "homepage": "https://github.com/NicoVogel/docker_extension#readme",
-  "dependencies": {},
+  "dependencies": {
+    "open": "^7.0.4"
+  },
   "devDependencies": {
     "@types/node": "^12.7.1",
     "@typescript-eslint/eslint-plugin": "^2.0.0",

--- a/src/@types/config.d.ts
+++ b/src/@types/config.d.ts
@@ -20,6 +20,4 @@ export interface Config {
 		// The value is a docker command with placeholders
 		[commandMapping: string]: string;
 	};
-	// open in editor command, needs to contain one placeholder $0 for the config file path
-	openEditorCommand: string;
 }

--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -44,7 +44,6 @@ export const defaultConfig: Config = {
 		bash: 'docker exec -it $0 /bin/bash',
 		rmdang: "docker rmi $(docker images -f 'dangling=true' -q)",
 		rmall: 'docker rm -v $(docker ps -aq)',
-    		rmselect: 'docker images | grep $0 | awk \'{ print $3; }\' | xargs docker rmi'
-	},
-	openEditorCommand: 'code $0'
+		rmselect: "docker images | grep $0 | awk '{ print $3; }' | xargs docker rmi"
+	}
 };

--- a/src/extensionCommands.ts
+++ b/src/extensionCommands.ts
@@ -1,5 +1,5 @@
-import { configLocation, configWriter, getConfig } from './configHandler';
-import { customRunner } from './runner';
+import * as open from 'open';
+import { configLocation, configWriter } from './configHandler';
 
 const helpLog = () =>
 	console.log(
@@ -21,12 +21,8 @@ const saveConfig = (args: string[]) => {
 };
 
 const editConfig = () => {
-	const openEditorCommand = getConfig().openEditorCommand.replace(
-		'$0',
-		configLocation
-	);
-	customRunner(openEditorCommand);
-	console.log('opening editor');
+	open(configLocation);
+	console.log('Opening editor');
 };
 
 export const evalExtensionCommand = (args: string[], processArgs: string[]) => {


### PR DESCRIPTION
If someone would like to use this extension, but hasn't installed VS Code, then it would be convenient to open the config file with the system's default editor. If this is VS code, it will continue to work as it is.